### PR TITLE
Add test coverage to phpunit configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ Thumbs.db
 .env
 /logs/*
 !/logs/README.md
+public/tests

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
             "@php -r \"file_exists('.env') || copy('.env.example', '.env'); \""
         ],
         "start": "php -S localhost:8080 -t public public/index.php",
-        "test": "phpunit",
+        "test": "vendor/bin/phpunit",
         "refresh-database": "php vendor/bin/phinx rollback -t0; php vendor/bin/phinx migrate; php vendor/bin/phinx seed:run"
     }
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,10 +19,15 @@
     <testsuite name="Unit Tests">
         <directory suffix="Test.php">./tests/Unit</directory>
     </testsuite>
-    <!--<logging>-->
-    <!--<log type="coverage-html" target="public/tests/coverage"/>-->
-    <!--<log type="testdox-html" target="public/tests/index.html"/>-->
-    <!--</logging>-->
+    <logging>
+        <log type="coverage-html" target="public/tests/coverage"/>
+        <log type="testdox-html" target="public/tests/index.html"/>
+    </logging>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="false">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
     <php>
         <env name="APP_ENV" value="testing"/>
 


### PR DESCRIPTION
Running `composer test` now will generate test coverage in
`public/tests/coverage`
The issue #3 is avoided by setting
processUncoveredFilesFromWhitelist=false