### PR TITLE
use Psr\Container\ContainerInterface

### DIFF
--- a/src/Conduit/Controllers/Article/ArticleController.php
+++ b/src/Conduit/Controllers/Article/ArticleController.php
@@ -5,7 +5,7 @@ namespace Conduit\Controllers\Article;
 use Conduit\Models\Article;
 use Conduit\Models\Tag;
 use Conduit\Transformers\ArticleTransformer;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use League\Fractal\Resource\Collection;
 use League\Fractal\Resource\Item;
 use Slim\Http\Request;
@@ -27,7 +27,7 @@ class ArticleController
     /**
      * UserController constructor.
      *
-     * @param \Interop\Container\ContainerInterface $container
+     * @param \Psr\Container\ContainerInterface $container
      *
      * @internal param $auth
      */

--- a/src/Conduit/Controllers/Article/CommentController.php
+++ b/src/Conduit/Controllers/Article/CommentController.php
@@ -6,7 +6,7 @@ use Conduit\Models\Article;
 use Conduit\Models\Comment;
 use Conduit\Transformers\ArticleTransformer;
 use Conduit\Transformers\CommentTransformer;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use League\Fractal\Resource\Collection;
 use League\Fractal\Resource\Item;
 use Slim\Http\Request;
@@ -28,7 +28,7 @@ class CommentController
     /**
      * UserController constructor.
      *
-     * @param \Interop\Container\ContainerInterface $container
+     * @param \Psr\Container\ContainerInterface $container
      *
      * @internal param $auth
      */

--- a/src/Conduit/Controllers/Article/FavoriteController.php
+++ b/src/Conduit/Controllers/Article/FavoriteController.php
@@ -4,7 +4,7 @@ namespace Conduit\Controllers\Article;
 
 use Conduit\Models\Article;
 use Conduit\Transformers\ArticleTransformer;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use League\Fractal\Resource\Item;
 use Slim\Http\Request;
 use Slim\Http\Response;
@@ -20,7 +20,7 @@ class FavoriteController
     /**
      * UserController constructor.
      *
-     * @param \Interop\Container\ContainerInterface $container
+     * @param \Psr\Container\ContainerInterface $container
      *
      * @internal param $auth
      */

--- a/src/Conduit/Controllers/Auth/LoginController.php
+++ b/src/Conduit/Controllers/Auth/LoginController.php
@@ -4,7 +4,7 @@ namespace Conduit\Controllers\Auth;
 
 use Conduit\Models\User;
 use Conduit\Transformers\UserTransformer;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use League\Fractal\Resource\Item;
 use Slim\Http\Request;
 use Slim\Http\Response;
@@ -25,7 +25,7 @@ class LoginController
     /**
      * RegisterController constructor.
      *
-     * @param \Interop\Container\ContainerInterface $container
+     * @param \Psr\Container\ContainerInterface $container
      */
     public function __construct(ContainerInterface $container)
     {

--- a/src/Conduit/Controllers/Auth/RegisterController.php
+++ b/src/Conduit/Controllers/Auth/RegisterController.php
@@ -4,7 +4,7 @@ namespace Conduit\Controllers\Auth;
 
 use Conduit\Models\User;
 use Conduit\Transformers\UserTransformer;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use League\Fractal\Resource\Item;
 use Slim\Http\Request;
 use Slim\Http\Response;
@@ -25,7 +25,7 @@ class RegisterController
     /**
      * RegisterController constructor.
      *
-     * @param \Interop\Container\ContainerInterface $container
+     * @param \Psr\Container\ContainerInterface $container
      */
     public function __construct(ContainerInterface $container)
     {

--- a/src/Conduit/Controllers/BaseController.php
+++ b/src/Conduit/Controllers/BaseController.php
@@ -2,20 +2,20 @@
 
 namespace Conduit\Controllers;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 class BaseController
 {
 
     /**
-     * @var \Interop\Container\ContainerInterface
+     * @var \Psr\Container\ContainerInterface
      */
     protected $container;
 
     /**
      * BaseController constructor.
      *
-     * @param \Interop\Container\ContainerInterface $container
+     * @param \Psr\Container\ContainerInterface $container
      */
     public function __construct(ContainerInterface $container)
     {

--- a/src/Conduit/Controllers/User/ProfileController.php
+++ b/src/Conduit/Controllers/User/ProfileController.php
@@ -5,7 +5,7 @@ namespace Conduit\Controllers\User;
 use Conduit\Models\User;
 use Conduit\Transformers\ProfileTransformer;
 use Conduit\Transformers\UserTransformer;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use League\Fractal\Resource\Item;
 use Slim\Http\Request;
 use Slim\Http\Response;
@@ -21,7 +21,7 @@ class ProfileController
     /**
      * UserController constructor.
      *
-     * @param \Interop\Container\ContainerInterface $container
+     * @param \Psr\Container\ContainerInterface $container
      *
      * @internal param $auth
      */

--- a/src/Conduit/Controllers/User/UserController.php
+++ b/src/Conduit/Controllers/User/UserController.php
@@ -3,7 +3,7 @@
 namespace Conduit\Controllers\User;
 
 use Conduit\Transformers\UserTransformer;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use League\Fractal\Resource\Item;
 use Slim\Http\Request;
 use Slim\Http\Response;
@@ -24,7 +24,7 @@ class UserController
     /**
      * UserController constructor.
      *
-     * @param \Interop\Container\ContainerInterface $container
+     * @param \Psr\Container\ContainerInterface $container
      *
      * @internal param $auth
      */

--- a/src/Conduit/Middleware/OptionalAuth.php
+++ b/src/Conduit/Middleware/OptionalAuth.php
@@ -2,21 +2,21 @@
 
 namespace Conduit\Middleware;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Slim\DeferredCallable;
 
 class OptionalAuth
 {
 
     /**
-     * @var \Interop\Container\ContainerInterface
+     * @var \Psr\Container\ContainerInterface
      */
     private $container;
 
     /**
      * OptionalAuth constructor.
      *
-     * @param \Interop\Container\ContainerInterface $container
+     * @param \Psr\Container\ContainerInterface $container
      *
      * @internal param \Slim\Middleware\JwtAuthentication $jwt
      */

--- a/src/Conduit/Services/Auth/AuthServiceProvider.php
+++ b/src/Conduit/Services/Auth/AuthServiceProvider.php
@@ -2,7 +2,7 @@
 
 namespace Conduit\Services\Auth;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 


### PR DESCRIPTION
Since container-interop/container-interop is deprecated and seems to throw exceptions in slim-php-realworld-example-app, let's switch to official Psr\Container\ContainerInterface.

Closes #21 